### PR TITLE
fix: search response 에서 도서 id 추가

### DIFF
--- a/src/main/java/com/nhnacademy/store99/bookstore/search/dto/BasicSearchResponse.java
+++ b/src/main/java/com/nhnacademy/store99/bookstore/search/dto/BasicSearchResponse.java
@@ -16,6 +16,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class BasicSearchResponse {
 
+    private Long bookId;
     private String bookTitle;
     private String bookThumbnailUrl;
     private List<BookAuthorInfo> bookAuthorInfos;

--- a/src/main/java/com/nhnacademy/store99/bookstore/search/query/BasicSearchQueryImpl.java
+++ b/src/main/java/com/nhnacademy/store99/bookstore/search/query/BasicSearchQueryImpl.java
@@ -65,6 +65,7 @@ public class BasicSearchQueryImpl extends QuerydslRepositorySupport implements B
             List<BasicSearchResponse.BookAuthorInfo> authorInfos =
                     authorsMap.getOrDefault(b.getId(), Collections.emptyList());
             return new BasicSearchResponse(
+                    b.getId(),
                     b.getBookTitle(),
                     b.getBookThumbnailUrl(),
                     authorInfos,

--- a/src/test/java/com/nhnacademy/store99/bookstore/search/controller/BasicSearchControllerTest.java
+++ b/src/test/java/com/nhnacademy/store99/bookstore/search/controller/BasicSearchControllerTest.java
@@ -37,6 +37,7 @@ class BasicSearchControllerTest extends RestDocSupport {
         // given
         List<BasicSearchResponse> searchResponseList = List.of(
                 BasicSearchResponse.builder()
+                        .bookId(1L)
                         .bookTitle("AI 2024 - 트렌드 & 활용백과")
                         .bookThumbnailUrl("https://image.aladin.co.kr/product/32628/53/cover/k822935456_1.jpg")
                         .bookAuthorInfos(List.of(
@@ -51,6 +52,7 @@ class BasicSearchControllerTest extends RestDocSupport {
                         .bookCntOfReview(0)
                         .build(),
                 BasicSearchResponse.builder()
+                        .bookId(2L)
                         .bookTitle("컴퓨터 밑바닥의 비밀 - 컴퓨터 시스템의 본질을 알면 코드의 실마리가 보인다")
                         .bookThumbnailUrl("https://image.aladin.co.kr/product/33564/48/cover/k602939885_1.jpg")
                         .bookAuthorInfos(List.of(
@@ -69,6 +71,7 @@ class BasicSearchControllerTest extends RestDocSupport {
                         .bookCntOfReview(0)
                         .build(),
                 BasicSearchResponse.builder()
+                        .bookId(3L)
                         .bookTitle("김으로 시작하는 책")
                         .bookThumbnailUrl("null.jpg")
                         .bookAuthorInfos(List.of(
@@ -83,6 +86,7 @@ class BasicSearchControllerTest extends RestDocSupport {
                         .bookCntOfReview(9999)
                         .build(),
                 BasicSearchResponse.builder()
+                        .bookId(4L)
                         .bookTitle("삼각김밥... 먹고싶다!")
                         .bookThumbnailUrl("null.jpg")
                         .bookAuthorInfos(List.of(

--- a/src/test/java/com/nhnacademy/store99/bookstore/search/service/BasicSearchServiceTest.java
+++ b/src/test/java/com/nhnacademy/store99/bookstore/search/service/BasicSearchServiceTest.java
@@ -33,6 +33,7 @@ class BasicSearchServiceTest {
         // exist
         List<BasicSearchResponse> existSearchList = List.of(
                 BasicSearchResponse.builder()
+                        .bookId(1L)
                         .bookTitle("AI 2024 - 트렌드 & 활용백과")
                         .bookThumbnailUrl("https://image.aladin.co.kr/product/32628/53/cover/k822935456_1.jpg")
                         .bookAuthorInfos(List.of(
@@ -47,6 +48,7 @@ class BasicSearchServiceTest {
                         .bookCntOfReview(0)
                         .build(),
                 BasicSearchResponse.builder()
+                        .bookId(2L)
                         .bookTitle("컴퓨터 밑바닥의 비밀 - 컴퓨터 시스템의 본질을 알면 코드의 실마리가 보인다")
                         .bookThumbnailUrl("https://image.aladin.co.kr/product/33564/48/cover/k602939885_1.jpg")
                         .bookAuthorInfos(List.of(
@@ -65,6 +67,7 @@ class BasicSearchServiceTest {
                         .bookCntOfReview(0)
                         .build(),
                 BasicSearchResponse.builder()
+                        .bookId(3L)
                         .bookTitle("김으로 시작하는 책")
                         .bookThumbnailUrl("null.jpg")
                         .bookAuthorInfos(List.of(
@@ -78,6 +81,7 @@ class BasicSearchServiceTest {
                         .bookCntOfReview(9999)
                         .build(),
                 BasicSearchResponse.builder()
+                        .bookId(4L)
                         .bookTitle("김으로 끝나는 책김책김")
                         .bookThumbnailUrl("null.jpg")
                         .bookAuthorInfos(List.of(
@@ -100,6 +104,7 @@ class BasicSearchServiceTest {
         // given
         List<BasicSearchResponse> givenSearchList = List.of(
                 BasicSearchResponse.builder()
+                        .bookId(1L)
                         .bookTitle("AI 2024 - 트렌드 & 활용백과")
                         .bookThumbnailUrl("https://image.aladin.co.kr/product/32628/53/cover/k822935456_1.jpg")
                         .bookAuthorInfos(List.of(
@@ -114,6 +119,7 @@ class BasicSearchServiceTest {
                         .bookCntOfReview(0)
                         .build(),
                 BasicSearchResponse.builder()
+                        .bookId(2L)
                         .bookTitle("컴퓨터 밑바닥의 비밀 - 컴퓨터 시스템의 본질을 알면 코드의 실마리가 보인다")
                         .bookThumbnailUrl("https://image.aladin.co.kr/product/33564/48/cover/k602939885_1.jpg")
                         .bookAuthorInfos(List.of(
@@ -132,6 +138,7 @@ class BasicSearchServiceTest {
                         .bookCntOfReview(0)
                         .build(),
                 BasicSearchResponse.builder()
+                        .bookId(3L)
                         .bookTitle("김으로 시작하는 책")
                         .bookThumbnailUrl("null.jpg")
                         .bookAuthorInfos(List.of(
@@ -145,6 +152,7 @@ class BasicSearchServiceTest {
                         .bookCntOfReview(9999)
                         .build(),
                 BasicSearchResponse.builder()
+                        .bookId(4L)
                         .bookTitle("김으로 끝나는 책김책김")
                         .bookThumbnailUrl("null.jpg")
                         .bookAuthorInfos(List.of(


### PR DESCRIPTION
front 에서 도서 id 를 활용하기 위해 도서 검색 응답 형식에 bookId 를 추가했습니다.
bookId 를 가져옴으로써 도서 리스트에서 해당 도서 상세 조회 api 를 활용할 수 있게 되었습니다.

![image](https://github.com/nhnacademy-be5-staff99/store99-bookstore/assets/114563915/86a6515d-fe4b-4025-9d39-2671bff39c71)
