### PR TITLE
feat: 메인 마이페이지 api

### DIFF
--- a/src/docs/asciidoc/basic-search.adoc
+++ b/src/docs/asciidoc/basic-search.adoc
@@ -1,4 +1,5 @@
 = 도서 조회 API : sql 사용
 
 == 도서 조회 성공
+
 operation::basic-search-controller-test/get-search-result[snippets="curl-request,http-request,http-response"]

--- a/src/main/java/com/nhnacademy/store99/bookstore/address/entity/Address.java
+++ b/src/main/java/com/nhnacademy/store99/bookstore/address/entity/Address.java
@@ -32,8 +32,8 @@ public class Address {
     @Column(name = "address_id", nullable = false)
     private Long id;
 
-    @Column(name = "address", nullable = false)
-    private String address;
+    @Column(name = "address_general", nullable = false)
+    private String addressGeneral;
 
     @Column(name = "address_detail", nullable = false)
     private String addressDetail;
@@ -43,6 +43,9 @@ public class Address {
 
     @Column(name = "address_code", nullable = false)
     private Integer addressCode;
+
+    @Column(name = "is_default_address", nullable = false)
+    private Boolean isDefaultAddress;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/nhnacademy/store99/bookstore/user/controller/MyPageController.java
+++ b/src/main/java/com/nhnacademy/store99/bookstore/user/controller/MyPageController.java
@@ -1,0 +1,27 @@
+package com.nhnacademy.store99.bookstore.user.controller;
+
+import com.nhnacademy.store99.bookstore.user.dto.MainMyPageResponse;
+import com.nhnacademy.store99.bookstore.user.service.MyPageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 메인 마이페이지 화면
+ *
+ * @author Ahyeon Song
+ */
+@RestController
+@RequestMapping("/v1/mypage")
+@RequiredArgsConstructor
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @GetMapping
+    public MainMyPageResponse getMainMyPage(@RequestHeader("X-USER-ID") Long xUserId) {
+        return myPageService.getMainMyPage(xUserId);
+    }
+}

--- a/src/main/java/com/nhnacademy/store99/bookstore/user/dto/MainMyPageResponse.java
+++ b/src/main/java/com/nhnacademy/store99/bookstore/user/dto/MainMyPageResponse.java
@@ -1,0 +1,46 @@
+package com.nhnacademy.store99.bookstore.user.dto;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 메인 마이페이지 화면 구성을 위한 응답
+ *
+ * @author Ahyeon Song
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+public class MainMyPageResponse {
+    private Long userId;
+    private String userName;
+    private String userEmail;
+    private String userPhoneNumber;
+    private LocalDate userBirthDay;
+    private Integer userPoint;
+    private UserAddress userAddress;
+    private UserGrade userGrade;
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class UserAddress {
+        private String addressGeneral;
+        private String addressDetail;
+        private String addressAlias;
+        private Integer addressCode;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class UserGrade {
+        private String gradeName;
+        private Integer gradeStartCost;
+        private Integer gradeEndCost;
+        private Integer gradeRatio;
+    }
+
+}

--- a/src/main/java/com/nhnacademy/store99/bookstore/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/nhnacademy/store99/bookstore/user/repository/UserRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.store99.bookstore.user.repository;
 
+import com.nhnacademy.store99.bookstore.user.dto.MainMyPageResponse;
 import com.nhnacademy.store99.bookstore.user.dto.UserAuthInfoByEmail;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -13,5 +14,7 @@ public interface UserRepositoryCustom {
     Optional<UserAuthInfoByEmail> getUserAuthInfoByEmail(String email);
 
     void updateLoginAt(Long id, LocalDateTime loginAt);
+
+    Optional<MainMyPageResponse> getMainMyPageByUserId(Long userId);
 
 }

--- a/src/main/java/com/nhnacademy/store99/bookstore/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/com/nhnacademy/store99/bookstore/user/repository/UserRepositoryImpl.java
@@ -1,7 +1,10 @@
 package com.nhnacademy.store99.bookstore.user.repository;
 
+import com.nhnacademy.store99.bookstore.address.entity.QAddress;
 import com.nhnacademy.store99.bookstore.auth.entity.QAuth;
 import com.nhnacademy.store99.bookstore.consumer.entity.QConsumer;
+import com.nhnacademy.store99.bookstore.grade.entity.QGrade;
+import com.nhnacademy.store99.bookstore.user.dto.MainMyPageResponse;
 import com.nhnacademy.store99.bookstore.user.dto.UserAuthInfoByEmail;
 import com.nhnacademy.store99.bookstore.user.entity.QUser;
 import com.nhnacademy.store99.bookstore.user.entity.User;
@@ -61,5 +64,49 @@ public class UserRepositoryImpl extends QuerydslRepositorySupport implements Use
                 .set(user.userLoginAt, loginAt)
                 .where(user.id.eq(id))
                 .execute();
+    }
+
+    /**
+     * id 로 기본 마이페이지에 들어가는 정보 검색
+     * <br>이름, 이메일, 주소, 연락처, 생일, 등급, 포인트
+     *
+     * @param userId
+     */
+    @Override
+    public Optional<MainMyPageResponse> getMainMyPageByUserId(Long userId) {
+        QUser user = QUser.user;
+        QConsumer consumer = QConsumer.consumer;
+        QGrade grade = QGrade.grade;
+        QAddress address = QAddress.address;
+
+        return Optional.ofNullable(
+                from(user)
+                        .join(user.consumers, consumer)
+                        .join(user.grade, grade)
+                        .leftJoin(address).on(user.eq(address.user))
+                        .where(user.id.eq(userId)
+                                .and(address.isDefaultAddress.isTrue()))
+                        .select(Projections.constructor(MainMyPageResponse.class,
+                                user.id,
+                                consumer.consumerName,
+                                consumer.consumerEmail,
+                                consumer.consumerPhone,
+                                user.userBirthdate,
+                                user.userPoint,
+                                Projections.constructor(MainMyPageResponse.UserAddress.class,
+                                        address.addressGeneral,
+                                        address.addressDetail,
+                                        address.addressAlias,
+                                        address.addressCode
+                                ),
+                                Projections.constructor(MainMyPageResponse.UserGrade.class,
+                                        grade.gradeName,
+                                        grade.gradeStartCost,
+                                        grade.gradeEndCost,
+                                        grade.gradeRatio)))
+                        .fetchOne()
+
+        );
+
     }
 }

--- a/src/main/java/com/nhnacademy/store99/bookstore/user/service/MyPageService.java
+++ b/src/main/java/com/nhnacademy/store99/bookstore/user/service/MyPageService.java
@@ -1,0 +1,35 @@
+package com.nhnacademy.store99.bookstore.user.service;
+
+import com.nhnacademy.store99.bookstore.user.dto.MainMyPageResponse;
+import com.nhnacademy.store99.bookstore.user.exception.UserNotFoundException;
+import com.nhnacademy.store99.bookstore.user.repository.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * mypage 와 관련된 로직
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 메인 마이페이지에 들어가는 정보
+     * <br>이름, 이메일, 주소, 연락처, 생일, 등급, 포인트
+     *
+     * @param xUserId
+     * @return
+     */
+    public MainMyPageResponse getMainMyPage(Long xUserId) {
+        Optional<MainMyPageResponse> myPageResponse = userRepository.getMainMyPageByUserId(xUserId);
+        if (myPageResponse.isEmpty()) {
+            throw new UserNotFoundException(xUserId);
+        }
+        return myPageResponse.get();
+    }
+}


### PR DESCRIPTION
# 메인 마이페이지 api

## `/api/bookstore/v1/mypage`
`X-USER-ID` header 와 일치하는 user 로 검색

## 고객 개인 정보
- [x] 이름
- [x] 이메일
- [x] 연락처
- [x] 생일
- [x] 거주지
- [x] 현재 등급
- [x] 현재 등급의 혜택
- [x] 현재 보유 포인트

## 알림 사항
address 쪽의 엔티티와 쿼리가 변경되었습니다! (address -> address_general 로 변경, is_default_address 추가)
ect 의 dml 과 ddl-ver.9 로 업데이트 해야합니다.

# 테스트 화면
![Image](https://github.com/nhnacademy-be5-staff99/store99-bookstore/assets/114563915/5992647c-fe7b-4248-b010-562b5c1a1c67)

## 한계
현재 쿼리의 한계 상 유저의 주소 중 `is_default_address 가 모두 false` 인 경우와 `주소가 하나도 등록되어있지 않은` 유저는 null, 즉 찾지 않습니다.
회원 가입 시 입력한 주소가 기본적으로 true 가 되도록 하므로 크게 문제가 되지는 않겠지만, 나중에 더 짜임새 있는 쿼리로 수정하겠습니다.

#89 
